### PR TITLE
Fix string interpolation

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -13,7 +13,7 @@ def populate(host, count, size, token):
     with click.progressbar(range(count), label='Creating test keys in Vault') as bar:
         for _ in bar:
             path = common.key_path()
-            r = s.post(f'{host}/v1/secret/test/{path}', json={'value': common.random_data(size)})
+            r = s.post("%s/v1/secret/test/%s" %(host,path), json={'value': common.random_data(size)})
             r.raise_for_status()
             paths.append(path)
 


### PR DESCRIPTION
I'm no Python expert but I've checked the docs and the existing string interpolation method should
work, but it's throwing an error for myself as well as the user who reported this issue:
https://github.com/hashicorp/vault-load-testing/issues/5

Switching the way string interpolation is done to this method allows prepare.py to work for me.
Tested with Python 3.4.9
*shrugs*

Fixes #5 for me, but I'm open to alternative solutions to this